### PR TITLE
Add support for prefixing user agent of S3 requests (via S3A)

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -114,5 +114,8 @@ public class Constants {
   
   public static final String S3N_FOLDER_SUFFIX = "_$folder$";
   public static final String FS_S3A_BLOCK_SIZE = "fs.s3a.block.size";
+
+  public static final String USER_AGENT_PREFIX = "fs.s3a.user.agent.prefix";
+
   public static final String FS_S3A = "s3a";
 }


### PR DESCRIPTION
This PR backports support for controlling user agent prefix of S3 requests (through s3a) via the `fs.s3a.user.agent.prefix` configuration.